### PR TITLE
Display file size correctly

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -612,7 +612,7 @@ $('form.process').on('decrypt:start', function(event, file) {
 	// Activate the input name tag.
 	$('form.process div.input.name').addClass('activated')
 	// Render input file size.
-	$('span.fileSize').text(miniLock.UI.readableFileSize(file.size))
+	$('form.process a.fileSize').text(miniLock.UI.readableFileSize(file.size))
 	// Animate decryption operation progress
 	miniLock.UI.animateProgressBar(0, file.size)
 })


### PR DESCRIPTION
When decryption begins it doesn't display the file size correctly. I have fixed it now.